### PR TITLE
configure BeautifulSoup parser to avoid warning and +x

### DIFF
--- a/pomfetch.py
+++ b/pomfetch.py
@@ -9,7 +9,7 @@ from bs4 import BeautifulSoup
 for i in range(1,7584):
     imgname = "POM0000" + format(i,"04d") + ".jpg"
     res = requests.get("https://commons.wikimedia.org/wiki/File:Pomological_Watercolor_" + imgname)
-    soup = BeautifulSoup(res.text)
+    soup = BeautifulSoup(res.text, "lxml")
     thumbs = soup.select('.mw-thumbnail-link')
 
     print("got thumbnails for " + imgname)


### PR DESCRIPTION
The bs parser was recommending that the "lxml" parser to avoid a startup
warning. The script has also been marked executable.

Feel free to discard this; just wanted to avoid the warning.