### PR TITLE
create a thumbs.json file

### DIFF
--- a/pomfetch.py
+++ b/pomfetch.py
@@ -1,27 +1,51 @@
 #!/usr/bin/env python3
 # Fetches a copy of each of the pomological watercolors, scaled.
 
-import os, requests, json
+import os, requests, json, os.path
 from io import BytesIO
 from PIL import Image
 from bs4 import BeautifulSoup
 
-for i in range(1,7584):
-    imgname = "POM0000" + format(i,"04d") + ".jpg"
-    res = requests.get("https://commons.wikimedia.org/wiki/File:Pomological_Watercolor_" + imgname)
-    soup = BeautifulSoup(res.text, "lxml")
-    thumbs = soup.select('.mw-thumbnail-link')
+data = []
+loaded = set()
 
-    print("got thumbnails for " + imgname)
+if os.path.exists("sources/thumbs.json"):
+    with open("sources/thumbs.json", "r") as thumbsJSON:
+        data = json.load(thumbsJSON)
+        for each in data:
+            loaded.add(each["id"])
 
-    if len(thumbs) == 0:
-        continue
+try:
+    for i in range(1,7584):
+        if i in loaded:
+            print("skipping: %d" % i)
+            continue
 
-    propersize = thumbs[len(thumbs)-2]
-    jpeg = propersize.get('href')
-    print("adding " + imgname)
+        imgname = "POM0000" + format(i,"04d") + ".jpg"
+        imgurl = "https://commons.wikimedia.org/wiki/File:Pomological_Watercolor_" + imgname
+        res = requests.get(imgurl)
+        soup = BeautifulSoup(res.text, "lxml")
+        thumbs = soup.select('.mw-thumbnail-link')
 
-    img = requests.get(jpeg)
-    photo = Image.open(BytesIO(img.content))
+        if len(thumbs) == 0:
+            print("no thumbnails at " + imgurl)
+            continue
 
-    photo.save("sources/" + imgname)
+        print("got thumbnails for " + imgname)
+        propersize = thumbs[len(thumbs)-2]
+        jpeg = propersize.get('href')
+        print("adding " + imgname)
+
+        img = requests.get(jpeg)
+        photo = Image.open(BytesIO(img.content))
+
+        photo.save("sources/" + imgname)
+        data.append({
+            'id':       i,
+            'filename': imgname,
+            'url':      jpeg,
+        })
+finally:
+    with open("sources/thumbs.json", "w") as thumbsJSON:
+        json.dump(data, thumbsJSON, indent=4)
+        thumbsJSON.write('\n')

--- a/pomfetch.py
+++ b/pomfetch.py
@@ -9,7 +9,7 @@ from bs4 import BeautifulSoup
 for i in range(1,7584):
     imgname = "POM0000" + format(i,"04d") + ".jpg"
     res = requests.get("https://commons.wikimedia.org/wiki/File:Pomological_Watercolor_" + imgname)
-    soup = BeautifulSoup(res.text)
+    soup = BeautifulSoup(res.text, "lxml")
     thumbs = soup.select('.mw-thumbnail-link')
 
     print("got thumbnails for " + imgname)


### PR DESCRIPTION
I was using this dataset and found that I sometimes wanted the wikimedia thumbnail URL in addition to or instead of the local file.

This PR builds a `thumbs.json` file as the pomological collection is processed. It can handle being interrupted.

The `thumbs.json` is rewritten after each successful image download. This is a little wasteful, but it means that the JSON can be used as a record of "good" downloads when resuming an interrupted run.

This `thumbs.json` pairs well with the `watercolors.json` in https://github.com/thisisparker/datasets.

This change builds upon my #1; I can strip that out if you decide it's unneeded.